### PR TITLE
Updated to Babel 6.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": ["es2015", "react", "stage-0"],
+  "plugins": [
+    "transform-runtime",
+    "babel-plugin-transform-decorators-legacy"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,20 +9,24 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^5.8.25",
+    "babel-runtime": "^6.6.1",
     "immutable": "^3.7.5",
     "react": "^0.14.3",
     "react-redux": "^4.0.0",
     "redux": "^3.0.4",
-    "redux-form": "^3.0.12",
-    "redux-immutablejs": "0.0.7"
+    "redux-form": "^4.2.2",
+    "redux-immutablejs": "0.0.8"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.2",
-    "html-webpack-plugin": "^1.7.0",
+    "babel-core": "^6.7.4",
+    "babel-eslint": "^6.0.0",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "html-webpack-plugin": "^2.15.0",
     "react-dom": "^0.14.3",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loaders: ['babel?optional[]=runtime&stage=0&cacheDirectory'],
+      loaders: ['babel']
     }]
   },
   plugins: [


### PR DESCRIPTION
Updated to Babel 6 by making use of `babel-plugin-transform-decorators-legacy`.
